### PR TITLE
Disable parallel release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
         tags: ['*']
 env:
     GITHUB_TAG: ${{ github.ref }}
+    GRADLE_OPTS: -Dorg.gradle.parallel=false
 jobs:
     tests:
         name: Test


### PR DESCRIPTION
I don't know why, but there's some race condition in publishing that's causing jars not to finish uploading. This might fix it temporarily